### PR TITLE
Support passing multiple paths as arguments

### DIFF
--- a/block_conv.py
+++ b/block_conv.py
@@ -119,7 +119,7 @@ def parse_args():
         return [None]
 
 
-def gather_markdown_files(targets, path="/docs"):
+def gather_markdown_files(targets, path="/work"):
     md_files = []
 
     # if there was no argument in argv

--- a/block_conv.py
+++ b/block_conv.py
@@ -112,7 +112,8 @@ def update_tabs(content):
 
 def parse_args():
     try:
-        return sys.argv[1]
+        # return paths if one or more files have been specified as arguments
+        return sys.argv[1:]
     # there's going to be an IndexError if no file/path argument was specified
     except IndexError:
         return None
@@ -136,9 +137,11 @@ def enumerate_markdown_files(target, path="/work"):
 if __name__ == "__main__":
     target = parse_args()
 
-    md_files = enumerate_markdown_files(target)
+    # enumerate/gather and flatten the lists into one
+    md_files = [file for t in target for file in enumerate_markdown_files(t)]
 
-    for md_file in md_files:
+    # remove duplicates and loop over the files
+    for md_file in set(md_files):
         content = md_file.read_text()
 
         content = update_admonition(content)

--- a/block_conv.py
+++ b/block_conv.py
@@ -116,32 +116,34 @@ def parse_args():
         return sys.argv[1:]
     # there's going to be an IndexError if no file/path argument was specified
     except IndexError:
-        return None
+        return [None]
 
 
-def enumerate_markdown_files(target, path="/work"):
+def gather_markdown_files(targets, path="/docs"):
+    md_files = []
+
     # if there was no argument in argv
-    if not target:
+    if not targets:
         # backward compatible with initial container configuration
-        md_files = list(Path(path).glob("**/*.md"))
+        md_files += list(Path(path).glob("**/*.md"))
     else:
-        if Path(target).is_file():
-            md_files = [Path(target)]
-        # must be a directory, right?
-        else:
-            md_files = list(Path(target).glob("**/*.md"))
+        for target in targets:
+            if Path(target).is_file():
+                md_files += [Path(target)]
+            # must be a directory, right?
+            else:
+                md_files += list(Path(target).glob("**/*.md"))
 
-    return md_files
+    # remove duplicates by type casting to a set
+    return set(md_files)
 
 
 if __name__ == "__main__":
-    target = parse_args()
+    targets = parse_args()
 
-    # enumerate/gather and flatten the lists into one
-    md_files = [file for t in target for file in enumerate_markdown_files(t)]
+    md_files = gather_markdown_files(targets)
 
-    # remove duplicates and loop over the files
-    for md_file in set(md_files):
+    for md_file in md_files:
         content = md_file.read_text()
 
         content = update_admonition(content)

--- a/tests/test_invocation.py
+++ b/tests/test_invocation.py
@@ -1,3 +1,4 @@
+from collections import Counter
 import unittest
 from unittest.mock import patch
 
@@ -26,37 +27,69 @@ class TestInvocation(unittest.TestCase):
 
         with patch("sys.argv", [self.prog, file]):
             target = block_conv.parse_args()
-            self.assertEqual(target, file)
 
-            md_files = block_conv.enumerate_markdown_files(target)
-            self.assertEqual(len(md_files), 1) and self.assertIs(
-                md_files, [file]
-            )
+            self.assertEqual(target[0], file)
+
+            md_files = block_conv.gather_markdown_files(target)
+            self.assertEqual(len(md_files), 1)
+            self.assertEqual([str(m) for m in md_files], [file])
 
     def test_arg_directory(self):
-        """Test the condition where a directory is the argument"""
+        """Test the condition where a single directory is the argument"""
         with patch("sys.argv", [self.prog, self.path]):
             target = block_conv.parse_args()
-            self.assertEqual(target, self.path)
 
-            md_files = block_conv.enumerate_markdown_files(target)
-            self.assertEqual(len(md_files), 3) and self.assertIs(
-                md_files, self.file_list
-            )
+            self.assertEqual(target[0], self.path)
+
+            md_files = list(block_conv.gather_markdown_files(target))
+            self.assertEqual(len(md_files), 3)
+            for m in md_files:
+                self.assertIn(str(m), self.file_list)
 
     def test_arg_missing(self):
         """Test the condition where an argument is not specified"""
-
         with patch("sys.argv", [self.prog]):
             target = block_conv.parse_args()
-            self.assertIsNone(target)
+            self.assertEqual(target, [])
 
-            md_files = block_conv.enumerate_markdown_files(
-                target, path=self.path
+            md_files = list(
+                block_conv.gather_markdown_files(
+                    target, path=self.path
+                )
             )
-            self.assertEqual(len(md_files), 3) and self.assertIs(
-                md_files, self.file_list
-            )
+
+            self.assertEqual(len(md_files), 3)
+            for m in md_files:
+                self.assertIn(str(m), self.file_list)
+
+    def test_arg_multiple_files(self):
+        """Test the condition where multiple file arguments are specified"""
+        files = [f"{self.path}/two.md", f"{self.path}/three.md"]
+
+        with patch("sys.argv", [self.prog, *files]):
+            target = block_conv.parse_args()
+
+            md_files = list(block_conv.gather_markdown_files(target))
+            self.assertEqual(len(md_files), 2)
+            for m in md_files:
+                self.assertIn(str(m), files)
+
+    def test_arg_multiple_file_dir(self):
+        """
+        Test the condition where multiple file and dir arguments are
+        specified. Also tests for the removal of duplicates.
+        """
+        files = [f"{self.path}/two.md", f"{self.path}"]
+
+        with patch("sys.argv", [self.prog, *files]):
+            target = block_conv.parse_args()
+
+            # parse first target (single file)
+            md_files = list(block_conv.gather_markdown_files(target))
+            self.assertEqual(len(md_files), 3)
+            for m in md_files:
+                self.assertIn(str(m), self.file_list)
+
 
 
 if __name__ == "__main__":

--- a/tests/test_invocation.py
+++ b/tests/test_invocation.py
@@ -1,4 +1,3 @@
-from collections import Counter
 import unittest
 from unittest.mock import patch
 
@@ -53,9 +52,7 @@ class TestInvocation(unittest.TestCase):
             self.assertEqual(target, [])
 
             md_files = list(
-                block_conv.gather_markdown_files(
-                    target, path=self.path
-                )
+                block_conv.gather_markdown_files(target, path=self.path)
             )
 
             self.assertEqual(len(md_files), 3)
@@ -79,17 +76,20 @@ class TestInvocation(unittest.TestCase):
         Test the condition where multiple file and dir arguments are
         specified. Also tests for the removal of duplicates.
         """
-        files = [f"{self.path}/two.md", f"{self.path}"]
+        paths = [f"{self.path}/two.md", f"{self.path}", "tests/admonition"]
+        path_list = [
+            *self.file_list,
+            "tests/admonition/admonition.md",
+            "tests/admonition/admonition_expected.md",
+        ]
 
-        with patch("sys.argv", [self.prog, *files]):
+        with patch("sys.argv", [self.prog, *paths]):
             target = block_conv.parse_args()
 
-            # parse first target (single file)
             md_files = list(block_conv.gather_markdown_files(target))
-            self.assertEqual(len(md_files), 3)
+            self.assertEqual(len(md_files), 5)
             for m in md_files:
-                self.assertIn(str(m), self.file_list)
-
+                self.assertIn(str(m), path_list)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
resolves #14 

* Support passing multiple files or directories as arguments
* Fix unit testing to accommodate the changes
* Add unit testing for multiple path arguments (file or directory)

:relaxed: